### PR TITLE
feature(yapf): add yapf formatter

### DIFF
--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -1,0 +1,31 @@
+name: Format with yapf
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  yapf-formater:
+    defaults:
+      run:
+        shell: bash
+        working-directory: scripts
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -r requirements.txt
+    - name: yapf formatter
+      env:
+        ACCESS_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        REPO_NAME: BobAnkh/LinuxBeginner
+        WORKING_PATH: scripts/
+      run: python yapf_formatter.py "$ACCESS_TOKEN" "$REPO_NAME" "$WORKING_PATH"

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -11,3 +11,4 @@ requests==2.24.0
 six==1.15.0
 urllib3==1.25.10
 wrapt==1.12.1
+yapf==0.30.0

--- a/scripts/yapf_formatter.py
+++ b/scripts/yapf_formatter.py
@@ -1,0 +1,30 @@
+from yapf.yapflib.yapf_api import FormatCode
+from github import Github
+import sys
+import re
+import base64
+
+ACCESS_TOKEN = []
+REPO_NAME = []
+WORKING_PATH = []
+ACCESS_TOKEN = sys.argv[1]
+REPO_NAME = sys.argv[2]
+WORKING_PATH = sys.argv[3]
+
+g = Github(ACCESS_TOKEN)
+repo = g.get_repo(REPO_NAME)
+contents = repo.get_contents(WORKING_PATH)
+
+pyscripts = []
+for content_file in contents:
+    if re.search(r'.py$', content_file.name) is not None:
+        pyscripts.append(content_file)
+
+for pyscript in pyscripts:
+    py_content = repo.get_contents(pyscript.path).content
+    py_content = base64.b64decode(py_content).decode('utf-8')
+    py_content = FormatCode(py_content)
+    if py_content[1]:
+        message = ("style(" + pyscript.name + "): format "
+                   "python script with yapf")
+        repo.update_file(pyscript.path, message, py_content[0], pyscript.sha)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please do remember to follow the contributing guidelines -->

## Description
<!--- Why is this change required? What problem does it solve? -->
This yapf formatter checks if all python scripts in repo BobAnkh/LinuxBeginner conform with yapf standard. If not, this formater can substitue with formatted python scripts. As the existing python scripts in folder `scripts/` are already formatted, this formatter can keep all python scripts in folder `scripts/` yapf-formatted.
<!--- Describe your changes in detail here to communicate to the maintainers why this pull request should be accepted -->
In branch **feature/yapf** I added two new file `yapf.yml` and `yapf_formatter.py` and added a line of dependent package yapf in `requirements.txt`. The formatter will work every hour. 
<!--- Describe your technology stack here if not a documentation update -->
<!--- Tasklist format is recommended for all pull requests and is required for all draft pull requests. You can couple your description with the tasklist -->
The following are the detailed steps:
- [x] Get access to a github repo using PyGithub: https://pygithub.readthedocs.io/en/latest/introduction.html. In `yapf_formatter.py`, Github(ACCESS_TOKEN), get_repo(REPO_NAME), get_contents(PATH) functions are applied to fetch content in folder `scripts/`, and update_file(PATH, message, content, sha) is applied to substitute the unformatted python scripts.
- [x] Detect all .py files using re: https://www.runoob.com/python/python-reg-expressions.html. In `yapf_formatter.py`, search() function are applied.
- [x] Decode .py contents using base64.decode(input) function: https://www.cnblogs.com/Security-Darren/p/3853054.html.
- [x] Format contents with yapf: https://github.com/google/yapf?utm_source=tuicool&utm_medium=referral. In `yapf_formatter.py`, FormatCode(string) function.
<!--- If it fixes an open issue, please link to the issue here in the last line. -->
Resolves: https://github.com/BobAnkh/LinuxBeginner/issues/26

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes locally -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- For example, markdown files should pass markdownlint locally according to the rules -->
<!--- See how your change affects other areas of the code, etc. -->
I've tested `yapf_formatter.py` locally on jupyter notebook and it managed to alter a testing python script of branch **master** in my forked repo, formatting a messy .py to a neat one. For example, space is automatically added before and after '=':
```python
a=[1,2,3,4]
# will be formatted as
a = [1, 2, 3, 4]
```
But illegal indentation won't be corrected by yapf formatter. This is because indentation in python is related to not only style but also its function, so formatter refuses to alter it. At this time, the action gives error information so that its author can change it to legal indentation.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Only left the line that best describes this pull request -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Code follows the code style of this project.
- [x] Changes follow the **CONTRIBUTING** guidelines.
- [x] Update necessary documentation accordingly.
- [x] Lint and tests pass locally with the changes.
- [x] Check issues and pull requests first. You don't want to duplicate effort.
